### PR TITLE
Remove `onwarn` compiler option

### DIFF
--- a/src/lib/importSvelte.ts
+++ b/src/lib/importSvelte.ts
@@ -10,7 +10,7 @@ export function importSvelte(importPath: string) {
 
     return {
         parse(text: string) {
-            return svelte.compile(text, { generate: false, onwarn: () => undefined }).ast;
+            return svelte.compile(text, { generate: false }).ast;
         },
     };
 }


### PR DESCRIPTION
The `onwarn` handler has been deprecated and removed from Svelte v3: sveltejs/svelte#2093