### PR TITLE
Fix whitespace trimming for lonely wrapped mustache tags

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -373,7 +373,16 @@ function trimLeft(group: Doc[]): void {
     }
 
     const first = group[0];
-    if (typeof first === 'string' || first.type !== 'fill') {
+    if (typeof first === 'string') {
+        return;
+    }
+
+    if (first.type === 'line') {
+        group.shift();
+        return;
+    }
+
+    if (first.type !== 'fill') {
         return;
     }
 
@@ -398,7 +407,16 @@ function trimRight(group: Doc[]): void {
     }
 
     const last = group[group.length - 1];
-    if (typeof last === 'string' || last.type !== 'fill') {
+    if (typeof last === 'string') {
+        return;
+    }
+
+    if (last.type === 'line') {
+        group.pop();
+        return;
+    }
+
+    if (last.type !== 'fill') {
         return;
     }
 

--- a/test/formatting/samples/wrap-element-attributes-and-children/input.html
+++ b/test/formatting/samples/wrap-element-attributes-and-children/input.html
@@ -1,0 +1,1 @@
+<a href="https://example.com" id="myLink" title="Go to this example website">{linkText}</a>

--- a/test/formatting/samples/wrap-element-attributes-and-children/output.html
+++ b/test/formatting/samples/wrap-element-attributes-and-children/output.html
@@ -1,0 +1,3 @@
+<a href="https://example.com" id="myLink" title="Go to this example website">
+    {linkText}
+</a>

--- a/test/printer/samples/element-with-attributes-and-mustache.html
+++ b/test/printer/samples/element-with-attributes-and-mustache.html
@@ -1,0 +1,1 @@
+<a href="https://example.com">{linkText}</a>

--- a/test/printer/samples/element-with-element-mustache.html
+++ b/test/printer/samples/element-with-element-mustache.html
@@ -1,0 +1,4 @@
+<div>
+    <MyIcon />
+    {score}
+</div>

--- a/test/printer/samples/element-with-several-attributes-and-mustache.html
+++ b/test/printer/samples/element-with-several-attributes-and-mustache.html
@@ -1,0 +1,3 @@
+<a href="https://example.com" id="myLink" title="Go to this example website">
+    {linkText}
+</a>


### PR DESCRIPTION
- [x] Add tests for handling different scenarios with lonely mustache tags
- [x] Fix group trimming when printing children so that mustache tags surrounded by only empty text nodes don't have unnecessary leading whitespace