### PR TITLE
add sort-order option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ Then format your code using prettier cli. You may need to add `--plugin-search-d
 ```
 prettier --write --plugin-search-dir=. ./**/*.html
 ```
+
+## Options
+
+**`sort-order`** Sort order for scripts, html, and css. Defaults to `scripts-css-html`.
+
+```
+prettier --write --sort-order scripts-html-css ./**/*.svelte
+```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.12.18",
-        "@types/prettier": "^1.16.3",
+        "@types/prettier": "^1.16.4",
         "ava": "1.2.0",
         "prettier": "^1.16.4",
         "rollup": "1.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { SupportLanguage, Parser, Printer, SupportOption } from 'prettier';
+import { SupportLanguage, Parser, Printer } from 'prettier';
 import { print } from './print';
 import { embed } from './embed';
 import { snipTagContent } from './lib/snipTagContent';
@@ -43,3 +43,5 @@ export const printers: Record<string, Printer> = {
         embed,
     },
 };
+
+export { options } from './options';

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,41 @@
+import { SupportOption } from 'prettier';
+
+declare module 'prettier' {
+    interface RequiredOptions extends PluginOptions {}
+}
+
+export interface PluginOptions {
+    sortOrder: SortOrder;
+}
+
+export const options: Record<keyof PluginOptions, SupportOption> = {
+    sortOrder: {
+        type: 'choice',
+        default: 'scripts-css-html',
+        description: 'Sort order for scripts, html, and css',
+        choices: [
+            { value: 'scripts-css-html' },
+            { value: 'scripts-html-css' },
+            { value: 'html-css-scripts' },
+            { value: 'html-scripts-css' },
+            { value: 'css-html-scripts' },
+            { value: 'css-scripts-html' },
+        ],
+    },
+};
+
+export type SortOrder =
+    | 'scripts-html-css'
+    | 'scripts-css-html'
+    | 'html-scripts-css'
+    | 'html-css-scripts'
+    | 'css-scripts-html'
+    | 'css-html-scripts';
+
+export type SortOrderPart = 'scripts' | 'html' | 'css';
+
+const sortOrderSeparator = '-';
+
+export function parseSortOrder(sortOrder: SortOrder): SortOrderPart[] {
+    return sortOrder.split(sortOrderSeparator) as SortOrderPart[];
+}

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -3,6 +3,7 @@ import { Node, MustacheTagNode, IfBlockNode } from './nodes';
 import { isASTNode } from './helpers';
 import { extractAttributes } from '../lib/extractAttributes';
 import { getText } from '../lib/getText';
+import { parseSortOrder, SortOrderPart } from '../options';
 const {
     concat,
     join,
@@ -35,28 +36,35 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
     }
 
     if (isASTNode(n)) {
-        const parts = [];
-        if (n.module) {
-            n.module.type = 'Script';
-            n.module.attributes = extractAttributes(getText(n.module, options));
-            parts.push(path.call(print, 'module'));
-        }
-        if (n.instance) {
-            n.instance.type = 'Script';
-            n.instance.attributes = extractAttributes(getText(n.instance, options));
-            parts.push(path.call(print, 'instance'));
-        }
-        if (n.css) {
-            n.css.type = 'Style';
-            n.css.content.type = 'StyleProgram';
-            parts.push(path.call(print, 'css'));
-        }
-
-        const htmlDoc = path.call(print, 'html');
-        if (htmlDoc) {
-            parts.push(htmlDoc);
-        }
-
+        const parts: doc.builders.Doc[] = [];
+        const addParts: Record<SortOrderPart, () => void> = {
+            scripts() {
+                if (n.module) {
+                    n.module.type = 'Script';
+                    n.module.attributes = extractAttributes(getText(n.module, options));
+                    parts.push(path.call(print, 'module'));
+                }
+                if (n.instance) {
+                    n.instance.type = 'Script';
+                    n.instance.attributes = extractAttributes(getText(n.instance, options));
+                    parts.push(path.call(print, 'instance'));
+                }
+            },
+            css() {
+                if (n.css) {
+                    n.css.type = 'Style';
+                    n.css.content.type = 'StyleProgram';
+                    parts.push(path.call(print, 'css'));
+                }
+            },
+            html() {
+                const htmlDoc = path.call(print, 'html');
+                if (htmlDoc) {
+                    parts.push(htmlDoc);
+                }
+            },
+        };
+        parseSortOrder(options.sortOrder).forEach(p => addParts[p]());
         return group(join(hardline, parts));
     }
 


### PR DESCRIPTION
This adds the `sort-order` option from issue #17 .

- I didn't add any tests. I'd be happy to take a look if you think it'd be helpful.
- I had to fix a mistake in the prettier types, hence the version bump.
- I put the option descriptions in the options file, rather than the root index, because I couldn't find a good way to get type safety for `options.sortOrder.choices`. Having everything in one place should make it easier to follow and avoid mistakes. That's the only big lack of type safety that I see - I'd be interested to learn if there's a good way to do it.

Wonderful project. ❤️ 