### PR TITLE
rename sort-order option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ prettier --write --plugin-search-dir=. ./**/*.html
 
 ## Options
 
-**`sort-order`** Sort order for scripts, html, and css. Defaults to `scripts-css-html`.
+**`sort-order`** Sort order for scripts, styles, and markup. Defaults to `scripts-styles-markup`.
 
 ```
-prettier --write --sort-order scripts-html-css ./**/*.svelte
+prettier --write --sort-order scripts-markup-styles ./**/*.svelte
 ```

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,28 +11,28 @@ export interface PluginOptions {
 export const options: Record<keyof PluginOptions, SupportOption> = {
     sortOrder: {
         type: 'choice',
-        default: 'scripts-css-html',
-        description: 'Sort order for scripts, html, and css',
+        default: 'scripts-styles-markup',
+        description: 'Sort order for scripts, styles, and markup',
         choices: [
-            { value: 'scripts-css-html' },
-            { value: 'scripts-html-css' },
-            { value: 'html-css-scripts' },
-            { value: 'html-scripts-css' },
-            { value: 'css-html-scripts' },
-            { value: 'css-scripts-html' },
+            { value: 'scripts-styles-markup' },
+            { value: 'scripts-markup-styles' },
+            { value: 'markup-styles-scripts' },
+            { value: 'markup-scripts-styles' },
+            { value: 'styles-markup-scripts' },
+            { value: 'styles-scripts-markup' },
         ],
     },
 };
 
 export type SortOrder =
-    | 'scripts-html-css'
-    | 'scripts-css-html'
-    | 'html-scripts-css'
-    | 'html-css-scripts'
-    | 'css-scripts-html'
-    | 'css-html-scripts';
+    | 'scripts-styles-markup'
+    | 'scripts-markup-styles'
+    | 'markup-styles-scripts'
+    | 'markup-scripts-styles'
+    | 'styles-markup-scripts'
+    | 'styles-scripts-markup';
 
-export type SortOrderPart = 'scripts' | 'html' | 'css';
+export type SortOrderPart = 'scripts' | 'markup' | 'styles';
 
 const sortOrderSeparator = '-';
 

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -50,14 +50,14 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                     parts.push(path.call(print, 'instance'));
                 }
             },
-            css() {
+            styles() {
                 if (n.css) {
                     n.css.type = 'Style';
                     n.css.content.type = 'StyleProgram';
                     parts.push(path.call(print, 'css'));
                 }
             },
-            html() {
+            markup() {
                 const htmlDoc = path.call(print, 'html');
                 if (htmlDoc) {
                     parts.push(htmlDoc);


### PR DESCRIPTION
This a stylistic change to the PR I made for #17  - feel free to disregard if you don't like the changes. It shouldn't be too disruptive because a release hasn't been cut. I renamed the options for `sort-order` from `css -> styles` and `html -> markup`. The reasoning is that both prettier and Svelte support many languages, so a generic name makes more sense and is more future-proof.