### PR TITLE
Disabled if blocks nested in an each/else from converting into else if

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -198,7 +198,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
         }
         case 'ElseBlock': {
             // Else if
-            const parent = path.getParentNode() as Node
+            const parent = path.getParentNode() as Node;
 
             if (node.children.length === 1 && node.children[0].type === 'IfBlock' && parent.type !== 'EachBlock') {
                 const ifNode = node.children[0] as IfBlockNode;

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,5 +1,5 @@
 import { FastPath, Doc, doc, ParserOptions } from 'prettier';
-import { Node, MustacheTagNode, IfBlockNode } from './nodes';
+import { Node, MustacheTagNode, IfBlockNode, EachBlockNode } from './nodes';
 import { isASTNode } from './helpers';
 import { extractAttributes } from '../lib/extractAttributes';
 import { getText } from '../lib/getText';
@@ -198,7 +198,9 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
         }
         case 'ElseBlock': {
             // Else if
-            if (node.children.length === 1 && node.children[0].type === 'IfBlock') {
+            const parent = path.getParentNode() as Node
+
+            if (node.children.length === 1 && node.children[0].type === 'IfBlock' && parent.type !== 'EachBlock') {
                 const ifNode = node.children[0] as IfBlockNode;
                 const def: Doc[] = [
                     '{:else if ',

--- a/test/printer/samples/each-block-else-with-nested-if-block-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block-else.html
@@ -1,0 +1,9 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}
+        <p>no dogs</p>
+    {:else}
+        <p>no animals</p>
+    {/if}
+{/each}

--- a/test/printer/samples/each-block-else-with-nested-if-block-elseif-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block-elseif-else.html
@@ -1,0 +1,11 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}
+        <p>no dogs</p>
+    {:else if type === 'cat'}
+        <p>no cats</p>
+    {:else}
+        <p>no animals</p>
+    {/if}
+{/each}

--- a/test/printer/samples/each-block-else-with-nested-if-block-elseif.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block-elseif.html
@@ -1,0 +1,9 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}
+        <p>no dogs</p>
+    {:else if type === 'cat'}
+        <p>no cats</p>
+    {/if}
+{/each}

--- a/test/printer/samples/each-block-else-with-nested-if-block.html
+++ b/test/printer/samples/each-block-else-with-nested-if-block.html
@@ -1,0 +1,7 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}
+        <p>no dogs</p>
+    {/if}
+{/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-else.html
@@ -1,0 +1,5 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}no dogs{:else}no animals{/if}
+{/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-elseif-else.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-elseif-else.html
@@ -1,0 +1,7 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}
+        no dogs
+    {:else if type === 'cat'}no cats{:else}no animals{/if}
+{/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline-elseif.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline-elseif.html
@@ -1,0 +1,5 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}no dogs{:else if type === 'cat'}no cats{/if}
+{/each}

--- a/test/printer/samples/each-block-else-with-nested-if-inline.html
+++ b/test/printer/samples/each-block-else-with-nested-if-inline.html
@@ -1,0 +1,5 @@
+{#each animals as animal}
+    <p>{animal}</p>
+{:else}
+    {#if type === 'dog'}no dogs{/if}
+{/each}


### PR DESCRIPTION
Fixes UnwrittenFun#32.

I tried to keep the code as lean as possible. All existing tests pass; I also added some tests to test this safeguard logic with most possible structures of if/else if/else blocks.

Let me know if I should pare down the tests, or if you'd like to see a few more.

If you'd like to take a different direction on solving this problem, just let me know.