### PR TITLE
Added handling for transition local modifier

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -318,6 +318,9 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 kind,
                 ':',
                 node.name,
+                node.modifiers && node.modifiers.indexOf('local') > -1
+                    ? concat(['|', 'local'])
+                    : '',
                 node.expression
                     ? concat(['=', open, printJS(path, print, 'expression'), close])
                     : '',

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -318,8 +318,8 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 kind,
                 ':',
                 node.name,
-                node.modifiers && node.modifiers.indexOf('local') > -1
-                    ? concat(['|', 'local'])
+                node.modifiers && node.modifiers.length
+                    ? concat(['|', join('|', node.modifiers)])
                     : '',
                 node.expression
                     ? concat(['=', open, printJS(path, print, 'expression'), close])

--- a/src/print/nodes.ts
+++ b/src/print/nodes.ts
@@ -170,6 +170,7 @@ export interface TransitionNode extends BaseNode {
     type: 'Transition';
     name: string;
     expression?: Node;
+    modifiers?: string[];
     intro: boolean;
     outro: boolean;
 }

--- a/test/printer/samples/transition-in-local.html
+++ b/test/printer/samples/transition-in-local.html
@@ -1,0 +1,1 @@
+<div in:fade|local>fades in</div>

--- a/test/printer/samples/transition-local.html
+++ b/test/printer/samples/transition-local.html
@@ -1,0 +1,1 @@
+<p transition:fade|local>fades in and out</p>

--- a/test/printer/samples/transition-out-local.html
+++ b/test/printer/samples/transition-out-local.html
@@ -1,0 +1,1 @@
+<div out:fade|local>fades out</div>

--- a/test/printer/samples/transition-with-expression-local.html
+++ b/test/printer/samples/transition-with-expression-local.html
@@ -1,0 +1,3 @@
+<p transition:fly|local={{ y: 200, duration: 1000 }}>
+    flies 200 pixels up, slowly
+</p>


### PR DESCRIPTION
Fixes UnwrittenFun#34.

This should resolve the aforementioned issue. I opted to simply concat `local` instead of all modifiers given that the `transition` directive only supports the `local` modifier. I can change this if desired, wasn't sure how much of the "validation" should be handled by the plugin versus the compiler.