### PR TITLE
Throw svelte errors in format prettier expects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,17 @@ export const languages: Partial<SupportLanguage>[] = [
 export const parsers: Record<string, Parser> = {
     svelte: {
         parse: text => {
-            return require(`svelte/compiler`).parse(text);
+            try {
+                return require(`svelte/compiler`).parse(text);
+            } catch (err) {
+                err.loc = {
+                    start: err.start,
+                    end: err.end,
+                };
+                delete err.start;
+                delete err.end;
+                throw err;
+            }
         },
         preprocess: text => {
             let styles: string[] = [];


### PR DESCRIPTION
In order to show a code frame prettier expects error objects to have `loc.start` and `loc.end` fields. Svelte emits errors with `start` and `end` fields. A quick modification to the error object and re-throwing and prettier can print code frames from svelte errors.