### PR TITLE
Use `prepare` to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "build": "rollup -c",
         "test": "ava",
-        "prepublishOnly": "npm test && npm run build"
+        "prepare": "npm run build",
+        "prepublishOnly": "npm test"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Use `prepare` to build. `prepare` is run when installing from git e.g. `npm install git+https://github.com/UnwrittenFun/prettier-plugin-svelte.git` allowing uses to install directly from master