### PR TITLE
Add strict mode for print html

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Format your svelte components using prettier.
 -   Format Svelte syntax, e.g. each loops, if statements, await blocks, etc.
 -   Format the javascript expressions embedded in the svelte syntax
     -   e.g. expressions inside of `{}`, event bindings `on:click=""`, and more
-    
+
 ## How to install
 
 ```bash
@@ -32,3 +32,10 @@ prettier --write --plugin-search-dir=. ./**/*.html
 ```
 prettier --write --svelte-sort-order scripts-markup-styles ./**/*.svelte
 ```
+
+**`svelte-strict-mode`** Enable more strict syntax for HTML. Defaults to `false`.
+
+Main difference in strict mode:
+
+-   [Not all tags are self closing](http://xahlee.info/js/html5_non-closing_tag.html)
+-   Expressions in attributes are wrapped by double quotes

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,6 +6,7 @@ declare module 'prettier' {
 
 export interface PluginOptions {
     svelteSortOrder: SortOrder;
+    svelteStrictMode: boolean;
     svelteBracketNewLine: boolean;
 }
 
@@ -22,6 +23,11 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
             { value: 'styles-markup-scripts' },
             { value: 'styles-scripts-markup' },
         ],
+    },
+    svelteStrictMode: {
+        type: 'boolean',
+        default: false,
+        description: 'More strict HTML syntax: self-closed tags, quotes in attributes',
     },
     svelteBracketNewLine: {
         type: 'boolean',

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -30,6 +30,24 @@ declare module 'prettier' {
     }
 }
 
+// @see http://xahlee.info/js/html5_non-closing_tag.html
+const SELF_CLOSING_TAGS = [
+    'area',
+    'base',
+    'br',
+    'col',
+    'embed',
+    'hr',
+    'img',
+    'input',
+    'link',
+    'meta',
+    'param',
+    'source',
+    'track',
+    'wbr',
+];
+
 export function print(path: FastPath, options: ParserOptions, print: PrintFn): Doc {
     const n = path.getValue();
     if (!n) {
@@ -69,7 +87,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
         return group(join(hardline, parts));
     }
 
-    const [open, close] = ['{', '}'];
+    const [open, close] = options.svelteStrictMode ? ['"{', '}"'] : ['{', '}'];
     const node = n as Node;
     switch (node.type) {
         case 'Fragment':
@@ -117,6 +135,9 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
         case 'Head':
         case 'Title': {
             const notEmpty = node.children.some(child => !isEmptyNode(child));
+            const isSelfClosingTag =
+                !notEmpty && (node.type !== 'Element' || SELF_CLOSING_TAGS.includes(node.name));
+
             return group(
                 concat([
                     '<',
@@ -135,17 +156,17 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                                     : '',
                                 ...path.map(childPath => childPath.call(print), 'attributes'),
                                 options.svelteBracketNewLine
-                                    ? dedent(notEmpty ? softline : line)
+                                    ? dedent(isSelfClosingTag ? softline : line)
                                     : '',
                             ]),
                         ),
                     ),
 
-                    notEmpty ? '>' : `${options.svelteBracketNewLine ? '' : ' '}/>`,
+                    isSelfClosingTag ? `${options.svelteBracketNewLine ? '' : ' '}/>` : '>',
 
                     notEmpty ? indent(printChildren(path, print)) : '',
 
-                    notEmpty ? concat(['</', node.name, '>']) : '',
+                    isSelfClosingTag ? '' : concat(['</', node.name, '>']),
                 ]),
             );
         }
@@ -189,7 +210,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
             const def: Doc[] = [line, node.name];
             if (node.value !== true) {
                 def.push('=');
-                const quotes = !hasLoneMustacheTag;
+                const quotes = !hasLoneMustacheTag || options.svelteStrictMode;
 
                 quotes && def.push('"');
                 def.push(...path.map(childPath => childPath.call(print), 'value'));
@@ -302,7 +323,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 node.name,
                 node.expression.type === 'Identifier' && node.expression.name === node.name
                     ? ''
-                    : concat(['=', '{', printJS(path, print, 'expression'), '}']),
+                    : concat(['=', open, printJS(path, print, 'expression'), close]),
             ]);
         case 'Class':
             return concat([
@@ -311,7 +332,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 node.name,
                 node.expression.type === 'Identifier' && node.expression.name === node.name
                     ? ''
-                    : concat(['=', '{', printJS(path, print, 'expression'), '}']),
+                    : concat(['=', open, printJS(path, print, 'expression'), close]),
             ]);
         case 'Let':
             return concat([
@@ -322,7 +343,7 @@ export function print(path: FastPath, options: ParserOptions, print: PrintFn): D
                 !node.expression ||
                 (node.expression.type === 'Identifier' && node.expression.name === node.name)
                     ? ''
-                    : concat(['=', '{', printJS(path, print, 'expression'), '}']),
+                    : concat(['=', open, printJS(path, print, 'expression'), close]),
             ]);
         case 'DebugTag':
             return concat([

--- a/test/printer/samples/attribute-quoted.html
+++ b/test/printer/samples/attribute-quoted.html
@@ -1,0 +1,9 @@
+<svelte:component this="{foo}" />
+
+<div style="width: {width}px"></div>
+
+<div class:awesome="{isOk}"></div>
+
+<input bind:value="{fooValue}" on:change="{onChange}" />
+
+<a use:link="{linkValues}">Link</a>

--- a/test/printer/samples/attribute-quoted.options.json
+++ b/test/printer/samples/attribute-quoted.options.json
@@ -1,0 +1,3 @@
+{
+    "svelteStrictMode": true
+}

--- a/test/printer/samples/self-closing-tags.html
+++ b/test/printer/samples/self-closing-tags.html
@@ -1,0 +1,35 @@
+<div></div>
+
+<span></span>
+
+<table></table>
+
+<MyComponent />
+
+<img />
+
+<input />
+
+<link />
+
+<br />
+
+<hr />
+
+<wbr />
+
+<area />
+
+<base />
+
+<col />
+
+<embed />
+
+<meta />
+
+<param />
+
+<source />
+
+<track />

--- a/test/printer/samples/self-closing-tags.options.json
+++ b/test/printer/samples/self-closing-tags.options.json
@@ -1,0 +1,3 @@
+{
+    "svelteStrictMode": true
+}


### PR DESCRIPTION
I glad to present changes from my fork =)

In this PR I added a new boolean option `svelte-strcit-mode` for two things in print HTML:
- For separating self-closing and non self-closing tags. It close #10
- For wrapping of attribute's values with double quotes

All things needed me for check a code by some html tools
