### PR TITLE
Added documentation for svelteBracketNewLine option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ and add your preferred configuration options:
   - Default: `true`
   - Option to enable/disable component attribute shorthand if attribute name and expression are same.
   
+- **`svelteBracketNewLine`**
+  - Default: `false`
+  - Put the `>` of a multiline element on a new line (svelte equivalent of [jsxBracketSameLine](https://prettier.io/docs/en/options.html#jsx-brackets) rule)
+
   For example:
 
   ```html
@@ -53,7 +57,8 @@ and add your preferred configuration options:
 {
   "svelteSortOrder" : "styles-scripts-markup",
   "svelteStrictMode": true,
-  "allowShorthand": false
+  "svelteBracketNewLine": true,
+  "svelteAllowShorthand": false
 }
 ```
 


### PR DESCRIPTION
Added docs for [svelteBracketNewLine](https://github.com/UnwrittenFun/prettier-plugin-svelte/blob/0006cf0eca5e2f2ba5b64d187455fa928d10b2ec/src/options.ts#L33) option as it is currently undocumented and is useful. Only found it via seeing issues. Helps with #66, #21 👍

Also fixed [svelteAllowShorthand](https://github.com/UnwrittenFun/prettier-plugin-svelte/blob/0006cf0eca5e2f2ba5b64d187455fa928d10b2ec/src/options.ts#L38) value in example `. prettierrc`, as it was previously `allowShorthand` and I think this was incorrect.